### PR TITLE
Trying cache test with localdev

### DIFF
--- a/.github/workflows/temp.yml
+++ b/.github/workflows/temp.yml
@@ -1,4 +1,4 @@
-name: Test
+name: Tests
 
 on:
   push:

--- a/.github/workflows/temp.yml
+++ b/.github/workflows/temp.yml
@@ -1,4 +1,4 @@
-name: Tests
+name: Test
 
 on:
   push:

--- a/.github/workflows/temp.yml
+++ b/.github/workflows/temp.yml
@@ -1,0 +1,71 @@
+name: Test
+
+on:
+  push:
+    tags:
+      - v*
+    branches-ignore:
+      - gh-pages
+  pull_request:
+    branches-ignore:
+      - gh-pages
+
+permissions:
+  contents: read
+  checks: write
+
+jobs:
+  go-temp:
+    name: Golang Bootstrap Test
+    runs-on: ubuntu-22.04
+    if: github.event_name == 'schedule' || github.event_name == 'push' || github.event.pull_request.head.repo.id != github.event.pull_request.base.repo.id
+
+    env:
+      ARMADA_EXECUTOR_INGRESS_URL: "http://localhost"
+      ARMADA_EXECUTOR_INGRESS_PORT: 5001
+      # Cache Docker layers in the GitHub actions cache.
+      # These variables are picked up by the goreleaser config.
+      DOCKER_BUILDX_CACHE_FROM: "type=gha"
+      DOCKER_BUILDX_CACHE_TO: "type=gha,mode=max"
+      DOCKER_BUILDX_BUILDER: "builder"
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3.3.0
+
+      - name: Create Docker Buildx Builder
+        run: docker buildx create --name ${DOCKER_BUILDX_BUILDER} --driver docker-container --use
+
+      - name: Install Docker Buildx
+        run: docker buildx install
+
+      - name: Free some disk space
+        run: docker image prune -af
+
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: "1.20"
+          cache: false
+
+      # Check for cache
+      - name: Cache Go modules
+        uses: actions/cache/restore@v3
+        with:
+          path: |
+            /home/runner/.cache/go-build
+            /home/runner/go/pkg/mod
+          key: ${{ runner.os }}-templocaldev-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-templocaldev-
+
+      - name: Run Our Bootstrap Test
+        run: go run github.com/magefile/mage@v1.14.0 -v localdev minimal testsuite
+
+      # Only save on master branch
+      - uses: actions/cache/save@v3
+        with:
+          path: |
+            /home/runner/.cache/go-build
+            /home/runner/go/pkg/mod
+          key: ${{ runner.os }}-templocaldev-${{ hashFiles('**/go.sum') }}

--- a/.github/workflows/temp.yml
+++ b/.github/workflows/temp.yml
@@ -55,9 +55,10 @@ jobs:
           path: |
             /home/runner/.cache/go-build
             /home/runner/go/pkg/mod
-          key: ${{ runner.os }}-templocaldev-${{ hashFiles('**/go.sum') }}
+            /home/runner/go/bin
+          key: ${{ runner.os }}-templocaldevwithbin-${{ hashFiles('**/go.sum') }}
           restore-keys: |
-            ${{ runner.os }}-templocaldev-
+            ${{ runner.os }}-templocaldevwithbin-
 
       - name: Run Our Bootstrap Test
         run: go run github.com/magefile/mage@v1.14.0 -v localdev minimal testsuite
@@ -68,4 +69,5 @@ jobs:
           path: |
             /home/runner/.cache/go-build
             /home/runner/go/pkg/mod
-          key: ${{ runner.os }}-templocaldev-${{ hashFiles('**/go.sum') }}
+            /home/runner/go/bin
+          key: ${{ runner.os }}-templocaldevwithbin-${{ hashFiles('**/go.sum') }}


### PR DESCRIPTION
Commit: 82708eb: setting up normal cache (`/home/runner/.cache/go-build` and `/home/runner/go/pkg/mod`) - takes 16m
Commit: 5104b53: using normal cache - takes 10m
Commit: 422c29c: setting up normal cache but also including `/home/runner/go/bin` - takes 17m
Commit: fb9a3b6: using this new cache - takes 11m

Therefore no timesave